### PR TITLE
Reframe Code of Conduct around Catholic social teaching

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code of Conduct
+
+## Our Mission
+ClankerOS is a general Christian project. We seek to glorify God through software that reflects the Good News and the Church's social teaching. Participation in our community should mirror the love of Christ and the dignity of every person.
+
+## Our Principles
+Grounded in Catholic Social Teaching, we strive to live out these principles:
+- **Life and Dignity of the Human Person**: Honor each person as made in the image of God; treat one another with respect and charity.
+- **Call to Family, Community, and Participation**: Welcome collaboration and build each other up as one body.
+- **Rights and Responsibilities**: Share knowledge generously and steward our gifts for the common good.
+- **Option for the Poor and Vulnerable**: Prefer solutions that uplift those on the margins.
+- **Dignity of Work and Rights of Workers**: Support fair workloads, encourage Sabbath rest, and value each contribution.
+- **Solidarity**: Stand together across cultures and backgrounds, seeking unity in Christ.
+- **Care for God's Creation**: Seek sustainable practices and mindful use of resources.
+
+## Community Support
+If you need guidance or wish to discuss how we can better live out these principles, contact [community@clankeros.org](mailto:community@clankeros.org).


### PR DESCRIPTION
## Summary
- restructure Code of Conduct around Catholic Social Teaching principles
- remove Contributor Covenant language and enforcement sections
- provide contact for community guidance

## Testing
- `nix develop --command bash -lc 'bazel test //...'` *(fails: command not found)*
- `./mk fmt` *(fails: No such file or directory)*
- `./mk lint` *(fails: No such file or directory)*
- `./mk hdl-lint` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab87eb45248332ae8d4ff517ee63b7