### PR TITLE
Add contribution guidelines and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Report a problem with ClankerOS
+labels: bug
+---
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+### Expected behavior
+What you expected to happen.
+
+### Screenshots or logs
+If applicable, add screenshots or logs to help explain your problem.
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for ClankerOS
+labels: enhancement
+---
+
+### Summary
+Describe the feature you would like.
+
+### Motivation
+Why is this feature important or helpful?
+
+### Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+- [ ] Linked issue, RFC, or ADR
+- [ ] Documentation updated
+- [ ] Tests added or updated
+
+## Testing
+Describe how you tested your changes. Include commands run:
+```
+nix develop -- bazel test //...
+./mk fmt
+./mk lint
+./mk hdl-lint
+```
+
+## Notes
+Any additional context.
+
+---
+By submitting this pull request, I certify that all commits are signed off and that I have the right to submit this contribution under the project's license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to ClankerOS
+
+Thank you for your interest in contributing to ClankerOS. This document outlines the workflow and Developer Certificate of Origin (DCO) requirements for all contributions.
+
+## Workflow
+
+1. **Plan**
+   - Review existing Issues, RFCs, or ADRs and reference them before starting work.
+2. **Branch**
+   - Create a branch named `feature/w{W}-area/short-desc`.
+3. **Develop & Test**
+   - Work inside a Nix shell and run tests:
+     ```
+     nix develop -- bazel test //...
+     ```
+   - Run pre-commit checks before submitting:
+     ```
+     ./mk fmt
+     ./mk lint
+     ./mk hdl-lint
+     ```
+   - Update documentation so specs stay in sync with code.
+4. **Open a Pull Request**
+   - Push your branch and open a PR using the provided template.
+   - Ensure CODEOWNERS approve impacted areas and keep history clean (squash or merge with DCO).
+5. **CI**
+   - If CI fails, fix issues and rerun until green before merge.
+
+## Developer Certificate of Origin
+
+All commits must be signed off to certify adherence to the Developer Certificate of Origin (DCO). Use:
+
+```
+git commit -s -m "Your commit message"
+```
+
+This adds a `Signed-off-by` line to your commit message and asserts that you have the right to submit your contribution under the project's license.
+
+Please also review our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guide covering workflow and DCO
- add issue and pull request templates

## Testing
- `nix develop -- bazel test //...` *(fails: command not found: nix)*
- `./mk fmt && ./mk lint && ./mk hdl-lint` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8c22a1d48332b05cb9192654f41b