### PR TITLE
docs: add data policy and LFS config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Configure Git LFS for large binary files.
+# See docs/governance/DATA-POLICY.md for details on artifact storage.
+
+*.bin filter=lfs diff=lfs merge=lfs -text
+*.tar.gz filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+artifacts/** filter=lfs diff=lfs merge=lfs -text

--- a/docs/governance/DATA-POLICY.md
+++ b/docs/governance/DATA-POLICY.md
@@ -1,0 +1,19 @@
+# Data & Artifact Storage Policy
+
+ClankerOS uses [Git Large File Storage (LFS)](https://git-lfs.github.com/) to version binary assets that must live alongside source code.
+
+## LFS Usage
+
+- Track binary files such as `.bin`, `.tar.gz`, and `.zip` with Git LFS.
+- Avoid committing generated or intermediate artifacts directly; use LFS only for sources requiring revision history.
+- Patterns for LFS tracking are declared in `.gitattributes`.
+
+## External Artifact Storage
+
+Large build or test outputs are not stored in Git. Instead:
+
+- Upload artifacts like FPGA bitstreams, compiled binaries, and datasets to an external object store (e.g., S3, GCS).
+- Reference external artifacts using URLs or metadata files in the repository.
+- Ensure each artifact is reproducible from source or accessible via the published storage location.
+
+This policy keeps the repository lightweight while enabling reproducible builds and audits.


### PR DESCRIPTION
## Summary
- document data and artifact storage policy
- configure Git LFS for common binary artifacts

## Testing
- `nix develop -- bazel test //...` *(fails: command not found)*
- `./mk fmt` *(fails: No such file or directory)*
- `./mk lint` *(fails: No such file or directory)*
- `./mk hdl-lint` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68ab8c366bf483329acd7af4401e314c