### PR TITLE
docs: add documentation structure and templates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation
+
+This directory organizes ClankerOS documentation.
+
+- `architecture/` — system design overviews, including SoC top-level structure, network-on-chip, hardware abstraction layer, and memory map.
+- `rfc/` — request for comments drafts and proposals.
+- `adr/` — architectural decision records capturing major decisions.
+

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,14 @@
+# ADR Title
+
+- Status: Draft
+- Date: YYYY-MM-DD
+
+## Context
+What is the issue that motivated this decision?
+
+## Decision
+What is the change that we're proposing and why?
+
+## Consequences
+What becomes easier or more difficult because of this decision?
+

--- a/docs/architecture/hal.md
+++ b/docs/architecture/hal.md
@@ -1,0 +1,4 @@
+# Hardware Abstraction Layer
+
+The HAL offers a uniform interface to SoC devices, hiding register-level details behind drivers and services. It manages initialization, interrupt handling, and common utilities used by higher level software.
+

--- a/docs/architecture/memory-map.md
+++ b/docs/architecture/memory-map.md
@@ -1,0 +1,4 @@
+# Memory Map
+
+ClankerOS assumes a flat physical address space covering boot ROM, SRAM, DRAM, and memory-mapped peripherals. Reserved regions document where system firmware, device registers, and kernel memory reside.
+

--- a/docs/architecture/noc.md
+++ b/docs/architecture/noc.md
@@ -1,0 +1,4 @@
+# Network-on-Chip
+
+The NoC links compute clusters, memory, and I/O through a scalable router topology. Packets carry memory and peripheral transactions across the fabric, enabling high-bandwidth communication between SoC components.
+

--- a/docs/architecture/soc-top.md
+++ b/docs/architecture/soc-top.md
@@ -1,0 +1,4 @@
+# SoC Top-Level Overview
+
+The ClankerOS system-on-chip integrates CPU cores, memory controllers, and peripheral blocks interconnected through the internal network-on-chip. The hardware abstraction layer initializes these components and coordinates boot and runtime services.
+

--- a/docs/rfc/template.md
+++ b/docs/rfc/template.md
@@ -1,0 +1,20 @@
+# RFC Title
+
+- Status: Draft
+- Date: YYYY-MM-DD
+
+## Summary
+Briefly describe the proposal.
+
+## Motivation
+Why is this change necessary?
+
+## Design
+Describe the proposed design.
+
+## Alternatives
+Discuss alternative approaches considered.
+
+## Unresolved Questions
+List open issues and follow-up work.
+


### PR DESCRIPTION
## Summary
- add documentation README outlining layout
- introduce architecture overview docs (SoC, NoC, HAL, memory map)
- provide RFC and ADR templates

## Testing
- `./mk fmt && ./mk lint && ./mk hdl-lint` *(fails: No such file or directory)*
- `nix develop -- bazel test //...` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8c474d3c83329ed38c122cb865ae